### PR TITLE
Add exists() + Expose signing options in getDownloadLink()

### DIFF
--- a/packages/storage-engine/package.json
+++ b/packages/storage-engine/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@omegadot/storage-engine",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"author": "Hendrik Gossler <h.gossler@omegadot.software>",
 	"exports": {
 		"import": "./dist/src/index.js",

--- a/packages/storage-engine/src/FileSystemStorageEngine.ts
+++ b/packages/storage-engine/src/FileSystemStorageEngine.ts
@@ -222,6 +222,19 @@ export class FileSystemStorageEngine extends StorageEngine {
 		}
 	}
 
+	async exists(fileName: string) {
+		try {
+			await stat(this.fullPath(fileName));
+		} catch (e) {
+			if (isENOENTError(e)) {
+				return false;
+			}
+			throw e;
+		}
+
+		return true;
+	}
+
 	private async open(
 		path: string,
 		flags = "r"

--- a/packages/storage-engine/src/S3StorageEngine.ts
+++ b/packages/storage-engine/src/S3StorageEngine.ts
@@ -14,6 +14,7 @@ import {
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { RequestPresigningArguments } from "@aws-sdk/types";
 import { assertDefined, assertInstanceof } from "@omegadot/assert";
 import {
 	createDuplex,
@@ -70,13 +71,34 @@ export class S3StorageEngine extends StorageEngine {
 		);
 	}
 
+	private headObjectCommand(fileName: string) {
+		return this.s3client.send(
+			new HeadObjectCommand(this.getBaseObject(fileName))
+		);
+	}
+
+	async exists(fileName: string) {
+		try {
+			await this.headObjectCommand(fileName);
+		} catch (e) {
+			if (
+				e instanceof S3ServiceException &&
+				e.$metadata.httpStatusCode === 404
+			) {
+				return false;
+			}
+
+			throw e;
+		}
+
+		return true;
+	}
+
 	async size(fileName: string) {
 		let info;
 
 		try {
-			info = await this.s3client.send(
-				new HeadObjectCommand(this.getBaseObject(fileName))
-			);
+			info = await this.headObjectCommand(fileName);
 		} catch (e) {
 			if (
 				e instanceof S3ServiceException &&
@@ -301,12 +323,14 @@ export class S3StorageEngine extends StorageEngine {
 	 *
 	 * @param {string} objectName - The name of the object in the S3 bucket.
 	 * @param {string} [fileName] - The name of the file to be used in the 'Content-Disposition' header.
+	 * @param options - RequestPresigningArguments
 	 *
 	 * @returns {Promise<string>} A promise that resolves to a presigned URL for the specified file.
 	 */
 	async getDownloadLink(
 		objectName: string,
-		fileName?: string
+		fileName?: string,
+		options?: RequestPresigningArguments
 	): Promise<string> {
 		const getObjectCommand = new GetObjectCommand(
 			fileName
@@ -316,7 +340,12 @@ export class S3StorageEngine extends StorageEngine {
 				  }
 				: this.getBaseObject(objectName)
 		);
-		return getSignedUrl(this.s3client, getObjectCommand, { expiresIn: 3600 });
+
+		return getSignedUrl(
+			this.s3client,
+			getObjectCommand,
+			options ? options : { expiresIn: 3600 }
+		);
 	}
 
 	async getUploadLink(uploadId: string): Promise<string> {

--- a/packages/storage-engine/src/StorageEngine.ts
+++ b/packages/storage-engine/src/StorageEngine.ts
@@ -37,6 +37,11 @@ export abstract class StorageEngine {
 	abstract size(fileName: string): Promise<number>;
 
 	/**
+	 * Returns true if the file exists, otherwise false.
+	 */
+	abstract exists(fileName: string): Promise<boolean>;
+
+	/**
 	 * Options can include start and end values to read a range of bytes from the file instead of the entire file.
 	 * Both start and end are inclusive and start counting at 0, allowed values are in the [0, Number.MAX_SAFE_INTEGER]
 	 * range.

--- a/packages/storage-engine/src/__tests__/storageEngineTestSuite.ts
+++ b/packages/storage-engine/src/__tests__/storageEngineTestSuite.ts
@@ -112,6 +112,16 @@ export function storageEngineTestSuite(
 			});
 		});
 
+		describe("exists()", () => {
+			test("returns true for existing file", async () => {
+				expect(await sto.exists("abc.txt")).toBe(true);
+			});
+
+			test("returns false for non existing file", async () => {
+				expect(await sto.exists("THIS_FILE_SHOULD_NOT_EXIST")).toBe(false);
+			});
+		});
+
 		describe("createReadStream()", () => {
 			test("streams file contents", async () => {
 				const stream = sto.createReadStream("abc.txt");

--- a/yarn.lock
+++ b/yarn.lock
@@ -2242,7 +2242,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@omegadot/storage-engine@^0.3.2, @omegadot/storage-engine@workspace:packages/storage-engine":
+"@omegadot/storage-engine@0.3.x, @omegadot/storage-engine@workspace:packages/storage-engine":
   version: 0.0.0-use.local
   resolution: "@omegadot/storage-engine@workspace:packages/storage-engine"
   dependencies:
@@ -2257,7 +2257,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@omegadot/streams@^0.1.2, @omegadot/streams@workspace:packages/streams":
+"@omegadot/streams@0.1.x, @omegadot/streams@^0.1.2, @omegadot/streams@workspace:packages/streams":
   version: 0.0.0-use.local
   resolution: "@omegadot/streams@workspace:packages/streams"
   dependencies:
@@ -2269,8 +2269,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@omegadot/tabular-data@workspace:packages/tabular-data"
   dependencies:
-    "@omegadot/storage-engine": ^0.3.2
-    "@omegadot/streams": ^0.1.2
+    "@omegadot/storage-engine": 0.3.x
+    "@omegadot/streams": 0.1.x
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
- Add `exists()` to check if a file exists
- Expose more S3 options in `getDownloadLink()`. This allows a more fine grained control of the signing options
- Bump version to 0.3.4